### PR TITLE
fix: geo link support google maps

### DIFF
--- a/enEditPanel.js
+++ b/enEditPanel.js
@@ -179,7 +179,7 @@ buttons.push({
 buttons.push({
   title: 'Координаты',
   icon: 'fa-map-marker-alt',
-  template: '<a href="geo:$selection;">$selection</a>',
+  template: '<a href="geo:$selection?q=$selection">$selection</a>',
 });
 buttons.push({
   title: 'Форма ответа',


### PR DESCRIPTION
Гугл карты поддерживают геоссылки не так как все остальные.

Они открывают место но не ставят метку на карте.
Чтобы появилась метка необходимо использовать параметр `q`


> [Google Maps](https://en.wikipedia.org/wiki/Google_Maps) adopts an unconventional approach to displaying the points: it shows the map for, but does not display a map pin, when a location is given in the standard way. A pin only shows up when given as the query. In other words, to show a pin at the [Wikimedia Foundation](https://en.wikipedia.org/wiki/Wikimedia_Foundation) office, one should not use geo:37.78918,-122.40335 but geo:0,0?q=37.78918,-122.40335.

Источник: (https://en.wikipedia.org/wiki/Geo_URI_scheme#Unofficial_extensions)